### PR TITLE
add fpm recipe for kafka-statsd-metrics2

### DIFF
--- a/kafka-statsd-metrics2/Makefile
+++ b/kafka-statsd-metrics2/Makefile
@@ -1,13 +1,19 @@
-NAME = storm-metrics-statsd
+NAME = kafka-statsd-metrics2
 VERSION = 0.4.1
 DEPENDS := kafka-server (>= 0.8.2.1)
-SOURCE_URL = https://bintray.com/artifact/download/airbnb/jars/com/airbnb/kafka-statsd-metrics2/0.4.1/kafka-statsd-metrics2-$(VERSION).jar
+SOURCE_URL = https://github.com/airbnb/kafka-statsd-metrics2/archive/master.zip
 FPM_SOURCE = dir
 PACKAGE_URL = https://github.com/airbnb/kafka-statsd-metrics2
 PACKAGE_DESCRIPTION = kafka-statsd-metrics2 is a module for Kafka that enables reporting metrics to statsd
 
 include ../include/base.mk
 
+default_fetch: $(CACHEDIR)
+	wget "$(SOURCE_URL)" -O $(CACHEDIR)/$(NAME).zip
+	cd $(CACHEDIR) && unzip $(NAME).zip 
+
 build: fetch default_build
-	mkdir -p $(DESTDIR)/usr/share/kafka \
-	&& cp $(CACHEDIR)/kafka-statsd-metrics2-$(VERSION).jar $(DESTDIR)/usr/share/kafka/
+	mkdir -p $(DESTDIR)/usr/share/kafka
+	cd $(CACHEDIR)/$(NAME)-master && \
+	./gradlew shadowJar --info
+	cp $(CACHEDIR)/$(NAME)-master/build/libs/$(NAME)-master-$(VERSION)-all.jar $(DESTDIR)/usr/share/kafka/

--- a/kafka-statsd-metrics2/Makefile
+++ b/kafka-statsd-metrics2/Makefile
@@ -16,4 +16,4 @@ build: fetch default_build
 	mkdir -p $(DESTDIR)/usr/share/kafka
 	cd $(CACHEDIR)/$(NAME)-master && \
 	./gradlew shadowJar --info
-	cp $(CACHEDIR)/$(NAME)-master/build/libs/$(NAME)-master-$(VERSION)-all.jar $(DESTDIR)/usr/share/kafka/$(NAME)-$(VERSION)-all.jar
+	cp $(CACHEDIR)/$(NAME)-master/build/libs/$(NAME)-master-$(VERSION)-all.jar $(DESTDIR)/usr/share/kafka/lib/$(NAME)-$(VERSION)-all.jar

--- a/kafka-statsd-metrics2/Makefile
+++ b/kafka-statsd-metrics2/Makefile
@@ -1,0 +1,13 @@
+NAME = storm-metrics-statsd
+VERSION = 0.4.1
+DEPENDS := kafka-server (>= 0.8.2.1)
+SOURCE_URL = https://bintray.com/artifact/download/airbnb/jars/com/airbnb/kafka-statsd-metrics2/0.4.1/kafka-statsd-metrics2-$(VERSION).jar
+FPM_SOURCE = dir
+PACKAGE_URL = https://github.com/airbnb/kafka-statsd-metrics2
+PACKAGE_DESCRIPTION = kafka-statsd-metrics2 is a module for Kafka that enables reporting metrics to statsd
+
+include ../include/base.mk
+
+build: fetch default_build
+	mkdir -p $(DESTDIR)/usr/share/kafka \
+	&& cp $(CACHEDIR)/kafka-statsd-metrics2-$(VERSION).jar $(DESTDIR)/usr/share/kafka/

--- a/kafka-statsd-metrics2/Makefile
+++ b/kafka-statsd-metrics2/Makefile
@@ -16,4 +16,4 @@ build: fetch default_build
 	mkdir -p $(DESTDIR)/usr/share/kafka
 	cd $(CACHEDIR)/$(NAME)-master && \
 	./gradlew shadowJar --info
-	cp $(CACHEDIR)/$(NAME)-master/build/libs/$(NAME)-master-$(VERSION)-all.jar $(DESTDIR)/usr/share/kafka/
+	cp $(CACHEDIR)/$(NAME)-master/build/libs/$(NAME)-master-$(VERSION)-all.jar $(DESTDIR)/usr/share/kafka/$(NAME)-$(VERSION)-all.jar


### PR DESCRIPTION
This uses the jars built by the project maintainers hosted on bintray.